### PR TITLE
fix proximity issue with out of range players in onesync infinity

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -2,6 +2,9 @@ RegisterNetEvent('esx_rpchat:sendProximityMessage')
 AddEventHandler('esx_rpchat:sendProximityMessage', function(playerId, title, message, color)
 	local player = PlayerId()
 	local target = GetPlayerFromServerId(playerId)
+    if Config.EnableOneSyncInfinity and target == -1 then
+        return
+    end
 
 	local playerPed = PlayerPedId()
 	local targetPed = GetPlayerPed(target)

--- a/config.lua
+++ b/config.lua
@@ -3,3 +3,4 @@ Config = {}
 Config.Locale = 'en'
 Config.OnlyFirstname = false
 Config.EnableESXIdentity = true -- only turn this on if you are using esx_identity and want to use RP names
+Config.EnableOneSyncInfinity = false


### PR DESCRIPTION
Fix the OneSync infinity issue described here https://forum.cfx.re/t/onesync-infinity-how-to-use-it/996612/89?u=babayaga22. Keep backwards compatibility for non infinity versions by including config flag.